### PR TITLE
Fix link to sideloading documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The only real limitation is screen size. Any full-screen Apple Watch should work
 
 ## How do I put this on my Apple Watch?
 
-By sideloading! This is a pretty complicated and involved process that will probably only make sense if you're a developer, but [here's](https://developer.apple.com/documentation/xcode/running-your-app-in-the-simulator-or-on-a-device) Apple's documentation on running custom apps on your devices using Xcode.
+By sideloading! This is a pretty complicated and involved process that will probably only make sense if you're a developer, but [here's](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device/) Apple's documentation on running custom apps on your devices using Xcode.
 
 ## Will this be posted to the App Store?
 


### PR DESCRIPTION
Apple changed one word of the title, referencing the Simulator rather than "in a simulation", breaking the link to the page on how to sideload apps.